### PR TITLE
PagSeguroConfig.xml na raiz do projeto

### DIFF
--- a/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
+++ b/source/Uol.PagSeguro/Resources/PagSeguroConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright [2011] [PagSeguro Internet Ltda.]
+// Copyright [2011] [PagSeguro Internet Ltda.]
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ using Uol.PagSeguro.Domain;
 using Uol.PagSeguro.XmlParse;
 using System.Reflection;
 using System.Diagnostics;
+using System.IO;
 
 namespace Uol.PagSeguro.Resources
 {
@@ -26,9 +27,9 @@ namespace Uol.PagSeguro.Resources
     /// </summary>
     public static class PagSeguroConfiguration
     {
-
-        private const string urlXmlConfiguration = ".../.../Configuration/PagSeguroConfig.xml";
-
+        //Capturando o caminho do arquivo
+        private static string caminho = Path.GetDirectoryName(Assembly.GetAssembly(typeof(PagSeguroConfiguration)).CodeBase);
+        private const string urlXmlConfiguration = "../Configuration/PagSeguroConfig.xml";
         private static string _moduleVersion;
         private static string _cmsVersion;
 
@@ -203,7 +204,7 @@ namespace Uol.PagSeguro.Resources
             XmlDocument xml = new XmlDocument();
             using (xml as IDisposable)
             {
-                xml.Load(urlXmlConfiguration);
+                xml.Load(Path.Combine(caminho, urlXmlConfiguration));
             }
             return xml;
         }


### PR DESCRIPTION
Capturando o patch do arquivo "PagSeguroConfig.xml" dinamicamente. Ao invés de buscar o arquivo citado acima na pasta "C:\Arquivos de programas\Arquivos comuns\Microsoft Shared\DevServer\10.0" passa a buscar na pasta raiz do projeto, onde a classe "AccountCredentials" está sendo importada, basta apenas adicionar a pasta "Configuration" com o arquivo "PagSeguroConfig.xml"
