### PR TITLE
Correção da url de busca de transação por código

### DIFF
--- a/source/Uol.PagSeguro/Service/TransactionSearchService.cs
+++ b/source/Uol.PagSeguro/Service/TransactionSearchService.cs
@@ -197,7 +197,7 @@ namespace Uol.PagSeguro.Service
             else
             {
                 searchUrlByCode = new QueryStringBuilder("{url}/{transactionCode}?{credential}");
-                searchUrlByCode.ReplaceValue("{url}", PagSeguroConfiguration.PreApprovalSearchUri.AbsoluteUri);
+                searchUrlByCode.ReplaceValue("{url}", PagSeguroConfiguration.SearchUri.AbsoluteUri);
                 searchUrlByCode.ReplaceValue("{transactionCode}", HttpUtility.UrlEncode(transactionCode));
             }
 


### PR DESCRIPTION
Correcao do método private static string BuildSearchUrlByCode(Credentials credentials, string transactionCode, bool preApproval)

Estava utilizando o endereço PagSeguroConfiguration.PreApprovalSearchUri quando deveria utilizar PagSeguroConfiguration.SearchUri
