### PR TITLE
Inclusão do endereço do pagador para assinaturas feitas com PreApproval

### DIFF
--- a/source/Examples/preApproval/CreatePreApproval/Program.cs
+++ b/source/Examples/preApproval/CreatePreApproval/Program.cs
@@ -28,7 +28,7 @@ namespace CreatePreApproval
         static void Main(string[] args)
         {
 
-            bool isSandbox = false;
+            bool isSandbox = true;
             EnvironmentConfiguration.ChangeEnvironment(isSandbox);
 
             // Instantiate a new preApproval request
@@ -57,7 +57,7 @@ namespace CreatePreApproval
             preApproval.PreApproval.MaxPaymentsPerPeriod = 5;
             preApproval.PreApproval.Details = string.Format("Todo dia {0} será cobrado o valor de {1} referente ao seguro contra roubo do Notebook.", now.Day, preApproval.PreApproval.AmountPerPayment.ToString("C2"));
             preApproval.PreApproval.Period = Period.Monthly;
-            preApproval.PreApproval.DayOfMonth = now.Day;
+            preApproval.PreApproval.DayOfMonth = now.Day <= 28 ? now.Day : 28;
             preApproval.PreApproval.InitialDate = now;
             preApproval.PreApproval.FinalDate = now.AddMonths(6);
             preApproval.PreApproval.MaxTotalAmount = 600.00m;
@@ -68,8 +68,13 @@ namespace CreatePreApproval
             // Sets the url used for user review the signature or read the rules
             preApproval.ReviewUri = new Uri("http://www.lojamodelo.com.br/revisao");
 
+            // Sets sender CPF
             SenderDocument senderCPF = new SenderDocument(Documents.GetDocumentByType("CPF"), "12345678909");
             preApproval.Sender.Documents.Add(senderCPF);
+
+            // Sets sender Address
+            Address senderAddress = new Address("BR", "RJ", "Rio de Janeiro", "Copacabana", "03351-800", "Avenida Copacabana", "1000", "2o Andar");
+            preApproval.Sender.Address = senderAddress;
 
             try
             {

--- a/source/Uol.PagSeguro/Domain/Sender.cs
+++ b/source/Uol.PagSeguro/Domain/Sender.cs
@@ -54,6 +54,15 @@ namespace Uol.PagSeguro.Domain
         }
 
         /// <summary>
+        /// Sender Address
+        /// </summary>
+        public Address Address
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Sender hash code
         /// </summary>
         public String Hash

--- a/source/Uol.PagSeguro/Parse/PreApprovalParse.cs
+++ b/source/Uol.PagSeguro/Parse/PreApprovalParse.cs
@@ -80,6 +80,62 @@ namespace Uol.PagSeguro.Parse
                         }
                     }
                 }
+
+                // address
+                if (preApproval.Sender.Address != null)
+                {
+                    var address = preApproval.Sender.Address;
+                    
+                    // country
+                    if (address.Country != null)
+                    {
+                        data["senderAddressCountry"] = address.Country;
+                    }
+
+                    // state
+                    if (address.State != null)
+                    {
+                        data["senderAddressState"] = address.State;
+                    }
+
+                    // city
+                    if (address.City != null)
+                    {
+                        data["senderAddressCity"] = address.City;
+                    }
+
+                    // PostalCode
+                    if (address.PostalCode != null)
+                    {
+                        data["senderAddressPostalCode"] = address.PostalCode;
+                    }
+
+                    // PostalCode
+                    if (address.District != null)
+                    {
+                        data["senderAddressDistrict"] = address.District;
+                    }
+
+                    // Complement
+                    if (address.Complement != null)
+                    {
+                        data["senderAddressComplement"] = address.Complement;
+                    }
+
+                    // Address Number
+                    if (address.Number != null)
+                    {
+                        data["senderAddressNumber"] = address.Number;
+                    }
+
+                    // Street
+                    if (address.Street != null)
+                    {
+                        data["senderAddressStreet"] = address.Street;
+                    }
+
+
+                }
             }
 
             data["preApprovalCharge"] = preApproval.PreApproval.Charge;


### PR DESCRIPTION
Na [documentação ](http://download.uol.com.br/pagseguro/docs/pagseguro-assinatura-automatica.pdf)constam informações sobre como informar o endereço do pagador, porém a implementação da classe Sender e PreApprovalParse não estavam contemplando o envio destas informações.
